### PR TITLE
security vulnerability: bump up mixin-deep version from 2.0.0 to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "binary-parser": "^1.3.2",
-    "mixin-deep": "^2.0.0"
+    "mixin-deep": "^2.0.1"
   }
 }


### PR DESCRIPTION
mixin-deep 2.0.0 has a CRITICAL security vulnerability.

Heads up!
[Please update](https://gist.github.com/jonschlinkert/9a62534c4f8bc76aee6058caa3f05fd6) to version 2.0.1 or later, a critical bug was fixed in that version.
[Components_vul_hepipe.pdf](https://github.com/user-attachments/files/19673771/Components_vul_hepipe.pdf)
